### PR TITLE
Workaround TypeError for blob

### DIFF
--- a/collabwrapper.py
+++ b/collabwrapper.py
@@ -737,7 +737,7 @@ class OutgoingBlobTransfer(_BaseOutgoingTransfer):
         _BaseOutgoingTransfer.__init__(
             self, buddy, conn, filename, description, mime)
 
-        self._blob = blob
+        self._blob = blob.encode('utf-8')
         self._create_channel(len(self._blob))
 
     def _get_input_stream(self):
@@ -881,3 +881,4 @@ class _TextChannelWrapper(object):
 
         return pservice.get_buddy_by_telepathy_handle(
             tp_name, tp_path, handle)
+


### PR DESCRIPTION
Blob had been using string in python2. After a python3 port, this error remianed possibly unfounded. The string in python2 has
been changed to bytes in python3. Using the encode to convert the python2 string to python3 bytes will remove some errors in some activities which handle large text transfers through OutgoingBlobTransfer