### PR TITLE
Use file transfer constants

### DIFF
--- a/collabwrapper.py
+++ b/collabwrapper.py
@@ -409,20 +409,25 @@ class CollabWrapper(GObject.GObject):
         return self._owner
 
 
-FT_STATE_NONE = 0
-FT_STATE_PENDING = 1
-FT_STATE_ACCEPTED = 2
-FT_STATE_OPEN = 3
-FT_STATE_COMPLETED = 4
-FT_STATE_CANCELLED = 5
+FT_STATE_NONE = TelepathyGLib.FileTransferState.NONE
+FT_STATE_PENDING = TelepathyGLib.FileTransferState.PENDING
+FT_STATE_ACCEPTED = TelepathyGLib.FileTransferState.ACCEPTED
+FT_STATE_OPEN = TelepathyGLib.FileTransferState.OPEN
+FT_STATE_COMPLETED = TelepathyGLib.FileTransferState.COMPLETED
+FT_STATE_CANCELLED = TelepathyGLib.FileTransferState.CANCELLED
 
-FT_REASON_NONE = 0
-FT_REASON_REQUESTED = 1
-FT_REASON_LOCAL_STOPPED = 2
-FT_REASON_REMOTE_STOPPED = 3
-FT_REASON_LOCAL_ERROR = 4
-FT_REASON_LOCAL_ERROR = 5
-FT_REASON_REMOTE_ERROR = 6
+FT_REASON_NONE = \
+    TelepathyGLib.FileTransferStateChangeReason.NONE
+FT_REASON_REQUESTED = \
+    TelepathyGLib.FileTransferStateChangeReason.REQUESTED
+FT_REASON_LOCAL_STOPPED = \
+    TelepathyGLib.FileTransferStateChangeReason.LOCAL_STOPPED
+FT_REASON_REMOTE_STOPPED = \
+    TelepathyGLib.FileTransferStateChangeReason.REMOTE_STOPPED
+FT_REASON_LOCAL_ERROR = \
+    TelepathyGLib.FileTransferStateChangeReason.LOCAL_ERROR
+FT_REASON_REMOTE_ERROR = \
+    TelepathyGLib.FileTransferStateChangeReason.REMOTE_ERROR
 
 
 class _BaseFileTransfer(GObject.GObject):

--- a/collabwrapper.py
+++ b/collabwrapper.py
@@ -742,7 +742,7 @@ class OutgoingBlobTransfer(_BaseOutgoingTransfer):
         _BaseOutgoingTransfer.__init__(
             self, buddy, conn, filename, description, mime)
 
-        self._blob = blob.encode('utf-8')
+        self._blob = blob
         self._create_channel(len(self._blob))
 
     def _get_input_stream(self):


### PR DESCRIPTION
Hard coded integer constants were used instead of enums imported from
TelepathyGLib.

Reported-by: Saumya Mishra <2017230@iiitdmj.ac.in>